### PR TITLE
Prevent multiple WebEventListeners from being added to WebDriverRunner #41

### DIFF
--- a/gui-tests/src/test/java/io.github.symonk/testcases/TestBaseTemplate.java
+++ b/gui-tests/src/test/java/io.github.symonk/testcases/TestBaseTemplate.java
@@ -10,6 +10,7 @@ import io.github.symonk.selenide.custom_listeners.CustomSelenideLogger;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Guice;
 
@@ -30,7 +31,7 @@ public class TestBaseTemplate {
     this.languageHelper = languageHelper;
   }
 
-  @BeforeMethod(alwaysRun = true, description = "[Register Driver Event Listener]")
+  @BeforeClass(alwaysRun = true, description = "[Register Driver Event Listener]")
   public void registerDriverEventListener() {
     WebDriverRunner.addListener(new WebEventListener());
   }


### PR DESCRIPTION
## Proposed changes

Modify *TestBaseTemplate* such that it only adds a new *WebEventListener* once per class instead of once per method. This prevents Selenium's *EventFiringWebDriver* (*on line 84*) from sending the same log message to 3 separate *WebEventListener*s. Addresses issue #41.

## Types of changes

What types of changes does your code introduce to Sylenium-framework with this pull request?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Details of changes

The following changes were made
* Only one *WebEventListener* is added when running *PuppyAdoptionTests*.

## Further comments

When running the *PuppyAdoptionTests* through a debugger, I was able to discover that as each test method was run, the amount of attached listeners on the *WebDriverRunner* increased by one. As this happened, logs *WebEventListener* logged would increase according to the amount of listeners that were registered.

I grabbed logs from before the change and after the change and analyzed them through UNIX pipes to make sure that no logs were dropped as a result:

```bash
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-1 ~/before.txt | grep WebEventListener | uniq | wc -l
      78
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-1 ~/after.txt | grep WebEventListener | uniq | wc -l
      78
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-2 ~/before.txt | grep WebEventListener | uniq | wc -l
      54
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-2 ~/after.txt | grep WebEventListener | uniq | wc -l
      54
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-3 ~/before.txt | grep WebEventListener | uniq | wc -l
      40
jitsusama@Joshua ~/I/sylenium-framework> grep Pack-3 ~/after.txt | grep WebEventListener | uniq | wc -l
      40
```